### PR TITLE
Replaced 4pda.ru with 4pda.to

### DIFF
--- a/useful_software_posts_and_links.md
+++ b/useful_software_posts_and_links.md
@@ -2,28 +2,28 @@ Almost everything is in Russian, use automatic translation.
 
 ## Useful posts
 
-* [Firmware for E3272, with modified partition table. Illustrates how to resize and reorder the partitions. The method should work with all Balong V7R2 series.](https://4pda.ru/forum/index.php?s=&showtopic=508842&view=findpost&p=77170885)
-* [Signed E5372 BootRom downgrade instruction. Kernel module example for Balong V7R1.](https://4pda.ru/forum/index.php?s=&showtopic=618520&view=findpost&p=63851093)
-* [Another kernel module example for Balong V7R1](https://4pda.ru/forum/index.php?s=&showtopic=618520&view=findpost&p=63653054)
-* [Disassembling and researching VxWorks on Balong V7R11 (part 1)](https://4pda.ru/forum/index.php?s=&showtopic=582284&view=findpost&p=36977362)
-* [Disassembling and researching VxWorks on Balong V7R11 (part 2)](https://4pda.ru/forum/index.php?s=&showtopic=582284&view=findpost&p=36981083)
-* [Hardware UART and its commands on Balong V7R11](https://4pda.ru/forum/index.php?s=&showtopic=582284&view=findpost&p=43382034)
-* [Balong V7R11 subsystems and their interraction](https://4pda.ru/forum/index.php?s=&showtopic=582284&view=findpost&p=56777431)
-* [Balong V7R11 boot sequence](https://4pda.ru/forum/index.php?s=&showtopic=582284&view=findpost&p=46553505)
-* [How to configure Cut-Thru Forwarding (ctf) on Balong V7R1/V7R2 with Broadcom Wi-Fi modules](https://4pda.ru/forum/index.php?s=&showtopic=618520&view=findpost&p=63157118)
-* [Hardware NAT acceleration (SPE) on Balong V7R22](https://4pda.ru/forum/index.php?s=&showtopic=842340&view=findpost&p=68814536)
+* [Firmware for E3272, with modified partition table. Illustrates how to resize and reorder the partitions. The method should work with all Balong V7R2 series.](https://4pda.to/forum/index.php?s=&showtopic=508842&view=findpost&p=77170885)
+* [Signed E5372 BootRom downgrade instruction. Kernel module example for Balong V7R1.](https://4pda.to/forum/index.php?s=&showtopic=618520&view=findpost&p=63851093)
+* [Another kernel module example for Balong V7R1](https://4pda.to/forum/index.php?s=&showtopic=618520&view=findpost&p=63653054)
+* [Disassembling and researching VxWorks on Balong V7R11 (part 1)](https://4pda.to/forum/index.php?s=&showtopic=582284&view=findpost&p=36977362)
+* [Disassembling and researching VxWorks on Balong V7R11 (part 2)](https://4pda.to/forum/index.php?s=&showtopic=582284&view=findpost&p=36981083)
+* [Hardware UART and its commands on Balong V7R11](https://4pda.to/forum/index.php?s=&showtopic=582284&view=findpost&p=43382034)
+* [Balong V7R11 subsystems and their interraction](https://4pda.to/forum/index.php?s=&showtopic=582284&view=findpost&p=56777431)
+* [Balong V7R11 boot sequence](https://4pda.to/forum/index.php?s=&showtopic=582284&view=findpost&p=46553505)
+* [How to configure Cut-Thru Forwarding (ctf) on Balong V7R1/V7R2 with Broadcom Wi-Fi modules](https://4pda.to/forum/index.php?s=&showtopic=618520&view=findpost&p=63157118)
+* [Hardware NAT acceleration (SPE) on Balong V7R22](https://4pda.to/forum/index.php?s=&showtopic=842340&view=findpost&p=68814536)
 * [One of possible methods to backup flash data](https://gist.github.com/ValdikSS/323bcdfceb2f09d9c6ef02db1bc573e2)
-* [Example of restoring NVRAM from backup on E5885](https://4pda.ru/forum/index.php?s=&showtopic=842340&view=findpost&p=67455208)
-* [Unpacking and repacking yaffs partitions on Balong V7R1](https://4pda.ru/forum/index.php?s=&showtopic=744265&view=findpost&p=72041932)
-* [Kernel memory modification without /dev/kmem access](https://4pda.ru/forum/index.php?s=&showtopic=744265&view=findpost&p=71881645)
-* [usbloader modification](https://4pda.ru/forum/index.php?s=&showtopic=744265&view=findpost&p=78454912)
-* [How to disable logging on V7R11 to increase flash memory livespan](https://4pda.ru/forum/index.php?s=&showtopic=678549&view=findpost&p=91927345)
-* [List of customization codes with digital signature (secuboot)](https://4pda.ru/forum/index.php?s=&showtopic=850369&view=findpost&p=94578681)
-* USB network fix for Balong V7R22 (E5885, E5785) in Linux: [patch for Linux](https://4pda.ru/forum/index.php?s=&showtopic=907081&view=findpost&p=94340926) or for [the device' kernel](https://4pda.ru/forum/index.php?s=&showtopic=907081&view=findpost&p=94476415)
+* [Example of restoring NVRAM from backup on E5885](https://4pda.to/forum/index.php?s=&showtopic=842340&view=findpost&p=67455208)
+* [Unpacking and repacking yaffs partitions on Balong V7R1](https://4pda.to/forum/index.php?s=&showtopic=744265&view=findpost&p=72041932)
+* [Kernel memory modification without /dev/kmem access](https://4pda.to/forum/index.php?s=&showtopic=744265&view=findpost&p=71881645)
+* [usbloader modification](https://4pda.to/forum/index.php?s=&showtopic=744265&view=findpost&p=78454912)
+* [How to disable logging on V7R11 to increase flash memory livespan](https://4pda.to/forum/index.php?s=&showtopic=678549&view=findpost&p=91927345)
+* [List of customization codes with digital signature (secuboot)](https://4pda.to/forum/index.php?s=&showtopic=850369&view=findpost&p=94578681)
+* USB network fix for Balong V7R22 (E5885, E5785) in Linux: [patch for Linux](https://4pda.to/forum/index.php?s=&showtopic=907081&view=findpost&p=94340926) or for [the device' kernel](https://4pda.to/forum/index.php?s=&showtopic=907081&view=findpost&p=94476415)
 * [List of NVRAM items](https://github.com/forth32/balong-nvtool/blob/master/nvid.c#L27)
-* [Move SMS storage to RAM](https://4pda.ru/forum/index.php?s=&showtopic=678549&view=findpost&p=92493865)
-* [Balong IPF patch to disable Multicast and Link-Local traffic block and IPv6 Prefix Delegation activation](https://4pda.ru/forum/index.php?s=&showtopic=678549&view=findpost&p=90297458)
-* [Installing ZeroTier VPN client for remote access to E8372](https://4pda.ru/forum/index.php?s=&showtopic=678549&view=findpost&p=80819168)
+* [Move SMS storage to RAM](https://4pda.to/forum/index.php?s=&showtopic=678549&view=findpost&p=92493865)
+* [Balong IPF patch to disable Multicast and Link-Local traffic block and IPv6 Prefix Delegation activation](https://4pda.to/forum/index.php?s=&showtopic=678549&view=findpost&p=90297458)
+* [Installing ZeroTier VPN client for remote access to E8372](https://4pda.to/forum/index.php?s=&showtopic=678549&view=findpost&p=80819168)
 
 
 ## Useful software:
@@ -39,6 +39,6 @@ Almost everything is in Russian, use automatic translation.
 
 ## Useful files
 
-* [Almost every USB loader](https://4pda.ru/forum/index.php?s=&showtopic=744265&view=findpost&p=74622408) ([also check this repo](https://github.com/forth32/balong-usbdload))
-* [usbloader and usblsafe for Balong V7R1 (E5372, E5776s, E392s, E3276, E5375 and others)](https://4pda.ru/forum/index.php?s=&showtopic=618520&view=findpost&p=93358441)
+* [Almost every USB loader](https://4pda.to/forum/index.php?s=&showtopic=744265&view=findpost&p=74622408) ([also check this repo](https://github.com/forth32/balong-usbdload))
+* [usbloader and usblsafe for Balong V7R1 (E5372, E5776s, E392s, E3276, E5375 and others)](https://4pda.to/forum/index.php?s=&showtopic=618520&view=findpost&p=93358441)
 * [Source code for GPL-licensed software and Linux kernel on Huawei OpenSource website](https://consumer.huawei.com/en/opensource/) (also available [as a list](https://consumer.huawei.com/en/opensource/detail/?siteCode=worldwide&fileType=openSourceSoftware&pageSize=10&curPage=1) + [mirror](ftp://serv.valdikss.org.ru/Downloads/Huawei_Open_Source/))


### PR DESCRIPTION
Since it appears the 4pda.ru forum was moved to 4pda.to I have replaced it in the links.